### PR TITLE
Updated .show()

### DIFF
--- a/fasterDOM.js
+++ b/fasterDOM.js
@@ -58,7 +58,7 @@
         },
         show: function () {
             this.each(function (element) {
-                element.style.display = 'block';
+                element.style.display = '';
             });
             return this;
         },


### PR DESCRIPTION
Old code meant that using .show() on an element that was supposed to be inline would set its display to block. Is this functionality preferred? 
